### PR TITLE
feat: allow columns to scroll independantly

### DIFF
--- a/nerdlets/top-nerdlet/process-details.js
+++ b/nerdlets/top-nerdlet/process-details.js
@@ -139,26 +139,28 @@ export default class ProcessDetails extends React.PureComponent {
             fullWidth
           >
             {this.renderSummaryPanel()}
-            {this.renderChart(
-              AreaChart,
-              'CPU',
-              "average(cpuSystemPercent) as 'System CPU %', average(cpuUserPercent) AS 'User CPU %'"
-            )}
-            {this.renderChart(
-              LineChart,
-              'I/O',
-              "average(ioReadBytesPerSecond/1024/1024) AS 'Read MB/s', average(ioWriteBytesPerSecond/1024/1024) AS 'Write MB/s'"
-            )}
-            {this.renderChart(
-              AreaChart,
-              'Resident Memory',
-              "average(memoryResidentSizeBytes) AS 'Resident'"
-            )}
-            {this.renderChart(
-              AreaChart,
-              'Virtual Memory',
-              "average(memoryVirtualSizeBytes) AS 'Virtual'"
-            )}
+            <div className="process-details-main">
+              {this.renderChart(
+                AreaChart,
+                'CPU',
+                "average(cpuSystemPercent) as 'System CPU %', average(cpuUserPercent) AS 'User CPU %'"
+              )}
+              {this.renderChart(
+                LineChart,
+                'I/O',
+                "average(ioReadBytesPerSecond/1024/1024) AS 'Read MB/s', average(ioWriteBytesPerSecond/1024/1024) AS 'Write MB/s'"
+              )}
+              {this.renderChart(
+                AreaChart,
+                'Resident Memory',
+                "average(memoryResidentSizeBytes) AS 'Resident'"
+              )}
+              {this.renderChart(
+                AreaChart,
+                'Virtual Memory',
+                "average(memoryVirtualSizeBytes) AS 'Virtual'"
+              )}
+            </div>
           </Stack>
         </ChartGroup>
       </div>

--- a/nerdlets/top-nerdlet/styles.scss
+++ b/nerdlets/top-nerdlet/styles.scss
@@ -87,9 +87,37 @@ table.process-table {
 }
 
 .process-details {
+  height: 100%;
+  overflow: hidden;
   padding-right: 8px;
+
   .chart {
     height: 180px;
     width: 100%;
   }
+
+  & > [class*='wnd-Stack'] {
+    height: 100%;
+    overflow: hidden;
+  }
+}
+
+.process-details-main {
+  height: 100%;
+  overflow: scroll;
+}
+
+.primary-grid {
+  height: 100%;
+  overflow: hidden;
+}
+
+[class*='GridItem'].column {
+  height: 100%;
+  overflow: hidden;
+}
+
+.primary-column-main {
+  height:100%;
+  overflow: scroll;
 }

--- a/nerdlets/top-nerdlet/top.js
+++ b/nerdlets/top-nerdlet/top.js
@@ -21,18 +21,22 @@ export default class Top extends React.PureComponent {
     const { selectedPid } = this.state;
 
     return (
-      <Grid>
-        <GridItem columnSpan={7} className="column">
-          <h1>Top Processes</h1>
-          <p className="subtitle">Refreshes every 15 seconds</p>
-          <ProcessTable
-            entity={entity}
-            selectedPid={selectedPid}
-            onSelectPid={this.selectPid}
-            {...this.props}
-          />
+      <Grid className="primary-grid">
+        <GridItem columnSpan={7} className="column primary-column">
+          <header className="column-header">
+            <h1>Top Processes</h1>
+            <p className="subtitle">Refreshes every 15 seconds</p>
+          </header>
+          <div className="primary-column-main">
+            <ProcessTable
+              entity={entity}
+              selectedPid={selectedPid}
+              onSelectPid={this.selectPid}
+              {...this.props}
+            />
+          </div>
         </GridItem>
-        <GridItem columnSpan={5} className="column">
+        <GridItem columnSpan={5} className="column secondary-column">
           {selectedPid ? (
             <ProcessDetails
               entity={entity}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nr1-top",
-    "version": "0.1.7",
+    "version": "0.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
When a user scrolls down to the bottom of the process list, and clicks on a process towards the bottom of the list, they no longer have to scroll back up to see the the charts.

Resolves newrelic/nr1-top#2