### PR TITLE
Update deprecated props on nr1 Icon

### DIFF
--- a/nerdlets/top-nerdlet/process-table.js
+++ b/nerdlets/top-nerdlet/process-table.js
@@ -167,10 +167,6 @@ export default class ProcessTable extends React.PureComponent {
                   {isSelected && (
                     <Icon
                       style={{ marginLeft: '6px' }}
-                      sizeType={
-                        Icon.SIZE_TYPE
-                          .INTERFACE__CARET__CARET_BOTTOM__WEIGHT_BOLD__SIZE_8
-                      }
                       color="#aaaaaa"
                       type="interface_caret_caret-bottom_weight-bold"
                     />


### PR DESCRIPTION
This PR removes the now deprecated sizeType prop from the nr1 Icon component (see docs [here](https://developer.newrelic.com/components/icon))

Here is a before and after of the Icon in question:
<img width="68" alt="Screen Shot 2021-01-28 at 11 24 38 AM" src="https://user-images.githubusercontent.com/39655074/106189464-31c85f00-615d-11eb-9b96-59b79dfdeb5c.png">
<img width="71" alt="Screen Shot 2021-01-28 at 11 25 27 AM" src="https://user-images.githubusercontent.com/39655074/106189469-3260f580-615d-11eb-90b9-bf5db7f2de8f.png">