### PR TITLE
Use major version for validate-nerdpack-action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,7 +127,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate Open Source Files
-        uses: newrelic/validate-nerdpack-action@v1.0.2
+        uses: newrelic/validate-nerdpack-action@v1
 
       - name: Install NR1 CLI
         run: |


### PR DESCRIPTION
This repo specifies an out of date patch version of `newrelic/validate-nerdpack-action`, this PR changes it to use the most up to date major version